### PR TITLE
Add code reference for LLM sps

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ This repository contains a regularly updated paper list for **Speculative Decodi
 ### Speculative Decoding for LLMs
 
 - **Fast Inference from Transformers via Speculative Decoding**  
-  *Yaniv Leviathan, Matan Kalman, Yossi Matias*. [[pdf](https://arxiv.org/pdf/2211.17192.pdf)], 2022.11. ![](https://img.shields.io/badge/ICML2023--Oral-orange) ![](https://img.shields.io/badge/Drafter:_smaller_LM-green)
+  *Yaniv Leviathan, Matan Kalman, Yossi Matias*. [[pdf](https://arxiv.org/pdf/2211.17192.pdf)], [[code](https://github.com/feifeibear/LLMSpeculativeSampling)], 2022.11. ![](https://img.shields.io/badge/ICML2023--Oral-orange) ![](https://img.shields.io/badge/Drafter:_smaller_LM-green)
 - **Accelerating Large Language Model Decoding with Speculative Sampling**  
-  *Charlie Chen, Sebastian Borgeaud, Geoffrey Irving, Jean-Baptiste Lespiau, Laurent Sifre, John Jumper*. [[pdf](http://arxiv.org/abs/2302.01318)], 2023.02. ![](https://img.shields.io/badge/Technical_Report-orange) ![](https://img.shields.io/badge/Drafter:_smaller_LM-green) ![](https://img.shields.io/badge/SpS-blue)
+  *Charlie Chen, Sebastian Borgeaud, Geoffrey Irving, Jean-Baptiste Lespiau, Laurent Sifre, John Jumper*. [[pdf](http://arxiv.org/abs/2302.01318)], [[code](https://github.com/feifeibear/LLMSpeculativeSampling)], 2023.02. ![](https://img.shields.io/badge/Technical_Report-orange) ![](https://img.shields.io/badge/Drafter:_smaller_LM-green) ![](https://img.shields.io/badge/SpS-blue) 
 - **Inference with Reference: Lossless Acceleration of Large Language Models**  
   *Nan Yang, Tao Ge, Liang Wang, Binxing Jiao, Daxin Jiang, Linjun Yang, Rangan Majumder, Furu Wei.* [[pdf](https://arxiv.org/pdf/2304.04487.pdf)], 2023.04. ![](https://img.shields.io/badge/Arxiv-orange) ![](https://img.shields.io/badge/Draft:_the_reference-green) ![](https://img.shields.io/badge/LLMA-blue)
 - **SpecInfer: Accelerating Generative LLM Serving with Speculative Inference and Token Tree Verification**  


### PR DESCRIPTION
I have included a code reference for DeepMind and Google's Sps paper in the repository. While this implementation may not be the official one (which could potentially be optimized for TPUs), I am confident that it will be of significant assistance to the readers of your comprehensive survey. I kindly request that you consider merging this pull request into the main branch to enhance the resource's value and utility.