### PR TITLE
Add DEL

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,8 @@ This repository contains a regularly updated paper list for **Speculative Decodi
   *Evangelos Georganas, Dhiraj Kalamkar, Alexander Kozlov, Alexander Heinecke*. [[pdf](https://arxiv.org/pdf/2503.13565)], 2025.03. ![](https://img.shields.io/badge/Arxiv-orange) ![](https://img.shields.io/badge/ML--SpecQD-blue)
 - **SPIN: Accelerating Large Language Model Inference with Heterogeneous Speculative Models**  
   *Fahao Chen, Peng Li, Tom H. Luan, Zhou Su, Jing Deng*. [[pdf](https://arxiv.org/pdf/2503.15921)], 2025.03. ![](https://img.shields.io/badge/INFOCOM2025-orange) ![](https://img.shields.io/badge/SPIN-blue)
+- **DEL: Context-Aware Dynamic Exit Layer for Efficient SelfSpeculative Decoding**  
+  *Hossein Entezari Zarch, Lei Gao, Chaoyi Jiang, Murali Annavaram*. [[pdf](https://arxiv.org/pdf/2504.05598)], 2025.04. ![](https://img.shields.io/badge/Arxiv-orange) ![](https://img.shields.io/badge/DEL-blue)
 
 ### Multimodal Speculative Decoding
 


### PR DESCRIPTION
This PR adds the paper "DEL: Context-Aware Dynamic Exit Layer for Efficient Self-Speculative Decoding" to the list. DEL is a lightweight, plug-and-play module built on top of LayerSkip that dynamically adjusts the exit layer and speculation length during inference to maximize decoding efficiency for LLMs. DEL achieves up to 2.50× speedup over standard auto-regressive decoding and improves upon state-of-the-art speculative decoding methods, while maintaining output quality across diverse tasks and models.

Paper: https://arxiv.org/abs/2504.05598