### PR TITLE
Add SpecReason

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,9 @@ This repository contains a regularly updated paper list for **Speculative Decodi
   *Changran Xu, Yi Liu, Yunhao Zhou, Shan Huang, Ningyi Xu, Qiang Xu*. [[pdf](https://arxiv.org/pdf/2503.14153)], 2025.03. ![](https://img.shields.io/badge/DAC2025-orange)
 - **A Multi-Model Adaptation of Speculative Decoding for Classification**  
   *Somnath Roy, Padharthi Sreekar, Srivatsa Narasimha, Anubhav Anand*. [[pdf](https://arxiv.org/pdf/2503.18076)], 2025.03. ![](https://img.shields.io/badge/Arxiv-orange)
+- **SpecReason: Fast and Accurate Inference-Time Compute via Speculative Reasoning**  
+  *Rui Pan, Yinwei Dai, Zhihao Zhang, Gabriele Oliaro, Zhihao Jia, Ravi Netravali*. [[pdf](https://arxiv.org/pdf/2504.07891)], 2025.04. ![](https://img.shields.io/badge/Arxiv-orange) ![](https://img.shields.io/badge/SpecReason-blue)
+  
 
 ### Analysis
 


### PR DESCRIPTION
Hi,

I’d like to suggest adding a recent work SpecReason: Fast and Accurate Inference-Time Compute via Speculative Reasoning to the list.

SpecReason accelerates Large Reasoning Model inference by using a lightweight model to (speculatively) carry out simpler intermediate reasoning steps and reserving the costly base model only to assess (and potentially correct) the speculated outputs.

Paper: https://arxiv.org/pdf/2504.07891

Thanks for considering!