### PR TITLE
Add AutoJudge, PARD, ASSD, and SCoT

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,10 @@ This repository contains a regularly updated paper list for **Speculative Decodi
   *Jiaming Xu, Jiayi Pan, Yongkang Zhou, Siming Chen, Jinhao Li, Yaoxiu Lian, Junyi Wu, Guohao Dai*. [[pdf](https://arxiv.org/pdf/2504.08850)], 2025.04. ![](https://img.shields.io/badge/ISCA2025-orange) ![](https://img.shields.io/badge/SpecEE-blue)
 - **Speculative Sampling via Exponential Races**  
   *Szymon Kobus, Deniz Gündüz*. [[pdf](https://arxiv.org/pdf/2504.15475)], 2025.04. ![](https://img.shields.io/badge/Arxiv-orange) ![](https://img.shields.io/badge/ERSD-blue)
+- **AutoJudge: Judge Decoding Without Manual Annotation**
+  *Roman Garipov, Fedor Velikonivtsev, Ruslan Svirschevski, Vage Egiazarian, Max Ryabinin*. [[pdf](https://arxiv.org/pdf/2504.20039)], [[code](https://github.com/garipovroma/autojudge)], 2025.04. ![](https://img.shields.io/badge/Arxiv-orange) ![](https://img.shields.io/badge/AutoJudge-blue)
+- **PARD: Accelerating LLM Inference with Low-Cost PARallel Draft Model Adaptation**
+  *Zihao An, Huajun Bai, Ziqiong Liu, Dong Li, Emad Barsoum*. [[pdf](https://arxiv.org/pdf/2504.18583)], 2025.04. ![](https://img.shields.io/badge/Arxiv-orange) ![](https://img.shields.io/badge/PARD-blue)
 
 ### Multimodal Speculative Decoding
 
@@ -476,6 +480,11 @@ This repository contains a regularly updated paper list for **Speculative Decodi
   *Rui Pan, Yinwei Dai, Zhihao Zhang, Gabriele Oliaro, Zhihao Jia, Ravi Netravali*. [[pdf](https://arxiv.org/pdf/2504.07891)], [[code](https://github.com/ruipeterpan/specreason)], 2025.04. ![](https://img.shields.io/badge/Arxiv-orange) ![](https://img.shields.io/badge/SpecReason-blue)
 - **Speculative Thinking: Enhancing Small-Model Reasoning with Large Model Guidance at Inference Time**  
   *Wang Yang, Xiang Yue, Vipin Chaudhary, Xiaotian Han*. [[pdf](https://arxiv.org/pdf/2504.12329)], [[code](https://github.com/uservan/speculative_thinking)], 2025.04. ![](https://img.shields.io/badge/Arxiv-orange) ![](https://img.shields.io/badge/Speculative_Thinking-blue)
+- **Reviving Any-Subset Autoregressive Models with Principled Parallel Sampling and Speculative Decoding**  
+  *Gabe Guo, Stefano Ermon*. [[pdf](https://arxiv.org/pdf/2504.20456)], [[code](https://github.com/gabeguo/any-order-speculative-decoding)], 2025.04. ![](https://img.shields.io/badge/Arxiv-orange) ![](https://img.shields.io/badge/ASSD-blue)
+- **Efficient Reasoning for LLMs through Speculative Chain-of-Thought**  
+  *Jikai Wang, Juntao Li, Lijun Wu, Min Zhang*. [[pdf](https://arxiv.org/pdf/2504.19095)], [[code](https://github.com/Jikai0Wang/Speculative_CoT)], 2025.04. ![](https://img.shields.io/badge/Arxiv-orange) ![](https://img.shields.io/badge/SCoT-blue)
+  
 
 ### Analysis
 


### PR DESCRIPTION
Hi,

I’d like to suggest adding 4 recent papers.

- AutoJudge proposes an improved version of Judge Decoding. 
- PARD proposes a training method that allows the autoregressive draft model to output draft tokens in parallel. 
- ASSD explores the use of speculative decoding for any-subset autoregressive models. 
- SCoT explores the use of speculative decoding to accelerate LongCoT tasks.

Thanks for considering!