### PR TITLE
Add MineDraft: A Framework for Batch Parallel Speculative Decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,8 @@ This repository contains a regularly updated paper list for **Speculative Decodi
   *Jian Chen, Yesheng Liang, Zhijian Liu*. [[pdf](https://arxiv.org/pdf/2602.06036)], [[homepage](https://z-lab.ai/projects/dflash/)], [[code](https://github.com/z-lab/dflash)], [[models](https://huggingface.co/collections/z-lab/dflash)], 2026.02. ![](https://img.shields.io/badge/Arxiv-orange)
 - **P-EAGLE: Parallel-Drafting EAGLE with Scalable Training**  
   *Mude Hui, Xin Huang, Jaime Campos Salas, Yue Sun, Nathan Pemberton, Xiang Song, Ashish Khetan, George Karypis*. [[pdf](https://arxiv.org/pdf/2602.01469)], 2026.02. ![](https://img.shields.io/badge/Arxiv-orange)
+- **MineDraft: A Framework for Batch Parallel Speculative Decoding**  
+  *Zhenwei Tang, Arun Verma, Zijian Zhou, Zhaoxuan Wu, Alok Prakash, Daniela Rus, Bryan Kian Hsiang Low*. [[pdf](https://arxiv.org/pdf/2603.18016)], [[code](https://github.com/electron-shaders/MineDraft)], 2026.03. ![](https://img.shields.io/badge/Arxiv-orange) ![](https://img.shields.io/badge/Batch_Parallel_Draft--Verify-lightgray) ![](https://img.shields.io/badge/MineDraft-blue)
 
 ### Multi-Token Prediction
 


### PR DESCRIPTION
Hi — thanks for maintaining this awesome list!

I'd like to suggest adding our recent paper, **MineDraft: A Framework for Batch Parallel Speculative Decoding**, which we think fits the scope of this list (speculative decoding / efficient LLM inference).

- **Paper:** https://arxiv.org/abs/2603.18016
- **Project blog:** https://arunv3rma.github.io/blogs/minedraft/minedraft.html
- **Code:** https://github.com/electron-shaders/MineDraft

**TL;DR:** MineDraft accelerates LLM inference by overlapping the *drafting* and *verification* stages of speculative decoding, hiding drafting latency behind verification compute. It maintains two batches of requests so that while one batch is being verified by the target model, the other is being drafted. Experiments on Qwen3, Llama-3.3, and EAGLE models across ShareGPT, LMSYS Arena, and Spec-Bench benchmarks achieve up to **+75% throughput** and **−39% end-to-end latency** over standard speculative decoding. Integrated into vLLM as a production plugin.

**BibTeX:**

```bibtex
@article{minedraft2026,
  title  = {MineDraft: A Framework for Batch Parallel Speculative Decoding},
  author = {Tang, Zhenwei and Verma, Arun and Zhou, Zijian and Wu, Zhaoxuan and Prakash, Alok and Rus, Daniela and Low, Bryan Kian Hsiang},
  journal = {arXiv preprint arXiv:2603.18016},
  year   = {2026},
  url    = {https://arxiv.org/abs/2603.18016}
}
```

Happy to reformat the entry or move it to a different section if you'd prefer — just let me know. Thanks for considering!
